### PR TITLE
使用ruamel.yaml库解析OpenUtau ustx文件

### DIFF
--- a/libresvip/plugins/ustx/ustx_converter.py
+++ b/libresvip/plugins/ustx/ustx_converter.py
@@ -1,6 +1,6 @@
 import pathlib
 
-import yaml
+from ruamel.yaml import YAML
 
 from libresvip.extension import base as plugin_base
 from libresvip.model.base import Project
@@ -11,23 +11,18 @@ from .options import InputOptions, OutputOptions
 from .ustx_generator import UstxGenerator
 from .ustx_parser import UstxParser
 
+y=YAML(typ='safe')
 
 class OpenUtauConverter(plugin_base.SVSConverterBase):
     def load(self, path: pathlib.Path, options: InputOptions) -> Project:
         proj_text = to_unicode(path.read_bytes())
         ustx_project = USTXProject.model_validate(
-            yaml.load(proj_text, getattr(yaml, "CSafeLoader", yaml.SafeLoader))
+            y.load(proj_text)
         )
         return UstxParser(options).parse_project(ustx_project)
 
     def dump(self, path: pathlib.Path, project: Project, options: OutputOptions) -> None:
         ustx_project = UstxGenerator(options).generate_project(project)
         proj_dict = ustx_project.model_dump(by_alias=True, exclude_none=True)
-        proj_text = yaml.dump(
-            proj_dict,
-            None,
-            getattr(yaml, "CSafeDumper", yaml.SafeDumper),
-            allow_unicode=True,
-            sort_keys=False,
-        )
+        proj_text = y.dump(proj_dict)
         path.write_bytes(proj_text.encode("utf-8"))


### PR DESCRIPTION
OpenUtau使用yaml 1.2， 而pyyaml仅支持yaml 1.1（参见[这个issue](https://github.com/yaml/pyyaml/issues/116)）

两者的一个重要区别是yaml 1.1会将yes, no, Y, N, on, off解析为布尔值，而yaml 1.2则只接受true和false，其他的都将解析为字符串。