### PR TITLE
lrc和ass支持忽略连音符；lrc拉丁语言自动空格分隔

### DIFF
--- a/libresvip/plugins/ass/ass_generator.py
+++ b/libresvip/plugins/ass/ass_generator.py
@@ -46,7 +46,7 @@ class AssGenerator:
         return lyric_lines
 
     def lyric_included(self, lyric: str) -> bool:
-        if(self.options.ignore_slur_notes):
+        if self.options.ignore_slur_notes:
             return lyric != "-"
         else:
             return True

--- a/libresvip/plugins/ass/ass_generator.py
+++ b/libresvip/plugins/ass/ass_generator.py
@@ -45,6 +45,12 @@ class AssGenerator:
                 buffer = []
         return lyric_lines
 
+    def lyric_included(self, lyric: str) -> bool:
+        if(self.options.ignore_slur_notes):
+            return lyric != "-"
+        else:
+            return True
+
     def commit_current_lyric_line(self, lyric_lines: list[SSAEvent], buffer: list[Note]) -> None:
         start_time = int(self.synchronizer.get_actual_secs_from_ticks(buffer[0].start_pos) * 1000)
         end_time = int(self.synchronizer.get_actual_secs_from_ticks(buffer[-1].end_pos) * 1000)
@@ -52,6 +58,7 @@ class AssGenerator:
             SYMBOL_PATTERN.sub("", note.lyric)
             + (" " if LATIN_ALPHABET.search(note.lyric) is not None else "")
             for note in buffer
+            if self.lyric_included(note.lyric)
         )
         lyric_lines.append(
             SSAEvent(

--- a/libresvip/plugins/ass/options.py
+++ b/libresvip/plugins/ass/options.py
@@ -43,8 +43,11 @@ class OutputOptions(SelectSingleTrackMixin, BaseModel):
         description=_("In milliseconds, positive means ahead, negative means opposite."),
     )
     split_by: SplitOption = Field(title=_("New line by"), default=SplitOption.BOTH)
-    ignore_slur_notes:bool = Field(
+    ignore_slur_notes: bool = Field(
         title=_("Ignore slur notes"),
-        description=_("Ignore '-' lyrics that are used to indicate slur notes in singing synthesizers."),
-        default=True)
+        description=_(
+            "Ignore '-' lyrics that are used to indicate slur notes in singing synthesizers."
+        ),
+        default=True,
+    )
     encoding: str = Field(title=_("Text encoding"), default="utf-8")

--- a/libresvip/plugins/ass/options.py
+++ b/libresvip/plugins/ass/options.py
@@ -43,4 +43,8 @@ class OutputOptions(SelectSingleTrackMixin, BaseModel):
         description=_("In milliseconds, positive means ahead, negative means opposite."),
     )
     split_by: SplitOption = Field(title=_("New line by"), default=SplitOption.BOTH)
+    ignore_slur_notes:bool = Field(
+        title=_("Ignore slur notes"),
+        description=_("Ignore '-' lyrics that are used to indicate slur notes in singing synthesizers."),
+        default=True)
     encoding: str = Field(title=_("Text encoding"), default="utf-8")

--- a/libresvip/plugins/lrc/lrc_generator.py
+++ b/libresvip/plugins/lrc/lrc_generator.py
@@ -82,7 +82,7 @@ class LrcGenerator:
         )
 
     def lyric_included(self, lyric: str) -> bool:
-        if(self.options.ignore_slur_notes):
+        if self.options.ignore_slur_notes:
             return lyric != "-"
         else:
             return True
@@ -93,9 +93,10 @@ class LrcGenerator:
         start_time = self.get_time_from_ticks(buffer[0][0])
         lyrics = ""
         for _, lyric in buffer:
-            if(self.lyric_included(lyric)):
-                lyrics += SYMBOL_PATTERN.sub("", lyric) \
-                    + (" " if LATIN_ALPHABET.search(lyric) is not None else "")
+            if self.lyric_included(lyric):
+                lyrics += SYMBOL_PATTERN.sub("", lyric) + (
+                    " " if LATIN_ALPHABET.search(lyric) is not None else ""
+                )
         lyric_lines.append(
             LyricLine(
                 time_tags=[

--- a/libresvip/plugins/lrc/lrc_generator.py
+++ b/libresvip/plugins/lrc/lrc_generator.py
@@ -3,7 +3,7 @@ import datetime
 
 from libresvip.core.time_sync import TimeSynchronizer
 from libresvip.model.base import Project, SingingTrack
-from libresvip.utils.text import SYMBOL_PATTERN
+from libresvip.utils.text import LATIN_ALPHABET, SYMBOL_PATTERN
 
 from .model import (
     AlbumInfoTag,
@@ -81,13 +81,21 @@ class LrcGenerator:
             info_tags=info_tags,
         )
 
+    def lyric_included(self, lyric: str) -> bool:
+        if(self.options.ignore_slur_notes):
+            return lyric != "-"
+        else:
+            return True
+
     def commit_current_lyric_line(
         self, lyric_lines: list[LyricLine], buffer: list[tuple[int, str]]
     ) -> None:
         start_time = self.get_time_from_ticks(buffer[0][0])
         lyrics = ""
         for _, lyric in buffer:
-            lyrics += SYMBOL_PATTERN.sub("", lyric)
+            if(self.lyric_included(lyric)):
+                lyrics += SYMBOL_PATTERN.sub("", lyric) \
+                    + (" " if LATIN_ALPHABET.search(lyric) is not None else "")
         lyric_lines.append(
             LyricLine(
                 time_tags=[

--- a/libresvip/plugins/lrc/options.py
+++ b/libresvip/plugins/lrc/options.py
@@ -70,6 +70,10 @@ class OutputOptions(BaseModel):
         title=_("Offset policy"), default=OffsetPolicyOption.TIMELINE
     )
     split_by: SplitOption = Field(title=_("New line by"), default=SplitOption.BOTH)
+    ignore_slur_notes:bool = Field(
+        title=_("Ignore slur notes"),
+        description=_("Ignore '-' lyrics that are used to indicate slur notes in singing synthesizers."),
+        default=True)
     timeline: bool = Field(
         title=_("Write timeline"),
         description=_("If you need lyrics without timeline, turn off this option."),

--- a/libresvip/plugins/lrc/options.py
+++ b/libresvip/plugins/lrc/options.py
@@ -70,10 +70,13 @@ class OutputOptions(BaseModel):
         title=_("Offset policy"), default=OffsetPolicyOption.TIMELINE
     )
     split_by: SplitOption = Field(title=_("New line by"), default=SplitOption.BOTH)
-    ignore_slur_notes:bool = Field(
+    ignore_slur_notes: bool = Field(
         title=_("Ignore slur notes"),
-        description=_("Ignore '-' lyrics that are used to indicate slur notes in singing synthesizers."),
-        default=True)
+        description=_(
+            "Ignore '-' lyrics that are used to indicate slur notes in singing synthesizers."
+        ),
+        default=True,
+    )
     timeline: bool = Field(
         title=_("Write timeline"),
         description=_("If you need lyrics without timeline, turn off this option."),


### PR DESCRIPTION
- 一般音乐网站里面的歌词都是不包含连音符`-`的，所以lrc和ass支持忽略连音符，默认忽略。
- 给lrc插件实现了ass插件同款拉丁语言自动空格分隔