### PR TITLE
Fix plugin load when pyzipper is not available

### DIFF
--- a/libresvip/plugins/ps_project/pocket_singer_parser.py
+++ b/libresvip/plugins/ps_project/pocket_singer_parser.py
@@ -1,7 +1,12 @@
 import dataclasses
 import pathlib
+from typing import TYPE_CHECKING
 
-from pyzipper import AESZipFile
+try:
+    from pyzipper import AESZipFile
+except ImportError:
+    if not TYPE_CHECKING:
+        AESZipFile = object
 
 from libresvip.core.time_sync import TimeSynchronizer
 from libresvip.model.base import (

--- a/libresvip/plugins/ps_project/pocket_singer_parser.py
+++ b/libresvip/plugins/ps_project/pocket_singer_parser.py
@@ -1,12 +1,10 @@
 import dataclasses
 import pathlib
-from typing import TYPE_CHECKING
 
 try:
     from pyzipper import AESZipFile
 except ImportError:
-    if not TYPE_CHECKING:
-        AESZipFile = object
+    AESZipFile = object  # type: ignore[misc, assignment]
 
 from libresvip.core.time_sync import TimeSynchronizer
 from libresvip.model.base import (


### PR DESCRIPTION
For a standard CLI install, pyzipper is not available by default. This causes the recursive plugin loading process to fail at the first plugin requiring it, resulting in formats like ustx becoming completely unreachable. This is fixed by only importing the module when available.