### PR TITLE
ustx：支持将+解析为音节分配符，将+~和+*解析为连音符

### DIFF
--- a/libresvip/plugins/ustx/options.py
+++ b/libresvip/plugins/ustx/options.py
@@ -10,6 +10,32 @@ from libresvip.model.option_mixins import (
 from libresvip.utils.translation import gettext_lazy as _
 
 
+class PlusHandlingMode(Enum):
+    _value_: Annotated[
+        str,
+        create_model(
+            "PlusHandlingMode",
+            __module__="libresvip.plugins.ustx.options",
+            AUTO=(str, Field(title=_("Auto determine by phonemizer language"))),
+            MONOSYLLABIC=(
+                str,
+                Field(title=_("Monosyllabic languages: treating +, +~ and +* as slur notes")),
+            ),
+            POLYSYLLABIC=(
+                str,
+                Field(
+                    title=_(
+                        "Polysyllabic languages: treating + as slur notes, and treating +~ or +* as syllable placerholders"
+                    )
+                ),
+            ),
+        ),
+    ]
+    AUTO = "auto"
+    MONOSYLLABIC = "monosyllabic"
+    POLYSYLLABIC = "polysyllabic"
+
+
 class OpenUtauEnglishPhonemizerCompatibility(Enum):
     _value_: Annotated[
         str,
@@ -29,10 +55,10 @@ class InputOptions(
     EnablePitchImportationMixin,
     BaseModel,
 ):
-    english_phonemizer_compatibility: OpenUtauEnglishPhonemizerCompatibility = Field(
-        OpenUtauEnglishPhonemizerCompatibility.NON_ARPA,
-        title=_("The way to handle english multisyllabic words"),
-        description=_("Compatibility with ARPAsing-series Phonemizer"),
+    plus_handling_mode: PlusHandlingMode = Field(
+        PlusHandlingMode.AUTO,
+        title=_("Plus sign handling mode"),
+        description=_("How to handle the + symbol in lyrics when importing USTX"),
     )
     breath_lyrics: str = Field(
         "Asp AP",

--- a/libresvip/plugins/ustx/ustx_parser.py
+++ b/libresvip/plugins/ustx/ustx_parser.py
@@ -157,7 +157,9 @@ class UstxParser:
         )
         return point_list
 
-    def parse_notes(self, notes: list[UNote], tick_prefix: int, monosyllabic_mode: bool) -> list[Note]:
+    def parse_notes(
+        self, notes: list[UNote], tick_prefix: int, monosyllabic_mode: bool
+    ) -> list[Note]:
         note_list = []
         prev_ustx_note = None
         for ustx_note in notes:

--- a/libresvip/plugins/ustx/ustx_parser.py
+++ b/libresvip/plugins/ustx/ustx_parser.py
@@ -157,7 +157,7 @@ class UstxParser:
         )
         return point_list
 
-    def parse_notes(self, notes: list[UNote], tick_prefix, monosyllabic_mode: bool) -> list[Note]:
+    def parse_notes(self, notes: list[UNote], tick_prefix: int, monosyllabic_mode: bool) -> list[Note]:
         note_list = []
         prev_ustx_note = None
         for ustx_note in notes:

--- a/libresvip/plugins/ustx/ustx_parser.py
+++ b/libresvip/plugins/ustx/ustx_parser.py
@@ -30,7 +30,7 @@ from .model import (
     UVoicePart,
     UWavePart,
 )
-from .options import InputOptions, OpenUtauEnglishPhonemizerCompatibility
+from .options import InputOptions, PlusHandlingMode
 from .util import BasePitchGenerator
 
 PHONETIC_HINT_RE = re.compile(r"\[(.*?)\]")
@@ -41,6 +41,19 @@ class UstxParser:
     options: InputOptions
     time_signatures: list[TimeSignature] = dataclasses.field(default_factory=list)
     base_pitch_generator: BasePitchGenerator = dataclasses.field(init=False)
+
+    def _is_monosyllabic_mode(self, phonemizer: str | None) -> bool:
+        if self.options.plus_handling_mode == PlusHandlingMode.MONOSYLLABIC:
+            return True
+        if self.options.plus_handling_mode == PlusHandlingMode.POLYSYLLABIC:
+            return False
+        if phonemizer is None:
+            return False
+        phonemizer_lower = phonemizer.lower()
+        return any(
+            lang in phonemizer_lower
+            for lang in ["chinese", "japanese", "korean", "cantonese", "vietnamese"]
+        )
 
     def parse_project(self, ustx_project: USTXProject) -> Project:
         self.breath_lyrics = self.options.breath_lyrics.strip().split()
@@ -109,7 +122,8 @@ class UstxParser:
                 continue
             if not singing_track.title:
                 singing_track.title = voice_part.name
-            notes = self.parse_notes(voice_part.notes, voice_part.position)
+            monosyllabic_mode = self._is_monosyllabic_mode(tracks[track_index].phonemizer)
+            notes = self.parse_notes(voice_part.notes, voice_part.position, monosyllabic_mode)
             singing_track.note_list.extend(notes)
             if self.options.import_pitch:
                 singing_track.edited_params.pitch.points.root.extend(self.parse_pitch(voice_part))
@@ -143,20 +157,16 @@ class UstxParser:
         )
         return point_list
 
-    def parse_notes(self, notes: list[UNote], tick_prefix: int) -> list[Note]:
+    def parse_notes(self, notes: list[UNote], tick_prefix, monosyllabic_mode: bool) -> list[Note]:
         note_list = []
         prev_ustx_note = None
         for ustx_note in notes:
             note_lyric = ustx_note.lyric
             if note_lyric.startswith("+"):
-                if (
-                    note_lyric.removeprefix("+").isdigit()
-                    and self.options.english_phonemizer_compatibility
-                    == OpenUtauEnglishPhonemizerCompatibility.ARPA
-                ):
-                    note_lyric = "+"
-                else:
+                if monosyllabic_mode or note_lyric == "+~" or note_lyric == "+*":
                     note_lyric = "-"
+                else:
+                    note_lyric = "+"
             note = Note(
                 key_number=ustx_note.tone,
                 lyric=note_lyric,


### PR DESCRIPTION
目前，OpenUtau的大多数多音节语言音素器都用`+~`和`+*`表示当前音符延续上一个音符的音节，相当于SynthV的`-`。以前，解析ustx时，libresvip不识别`+~`和`+*`，它们和`+`都被转换为`-`。这种模式适合单音节语言，但不适合英语等多音节语言。

这里添加了一个“加号处理方式”的选项，包括：
- 自动：根据工程文件中声明的音素器决定
- 单音节：将`+~`、`+*`、`+`都转换为`-`，与旧行为一致
- 多音节：将`+~`、`+*`转换为`-`，`+`保持不变

此外，移除了ustx解析器的“ARPA系列音素器兼容性”选项。ARPA系列音素器除支持`+`表示放置新音节，`+~`和`+*`表示延续当前音节外，还支持用`+n`表示当前音符开头与单词的第n个音素（不是音节）对齐。这个在目前的libresvip中实现不正确。如果需要准确兼容，可以内置英文cmudict，但逻辑较复杂。因此暂不实现。

---

场景：我正在开发 https://github.com/oxygen-dioxide/music21-svs-formats ，目的之一是将歌声合成工程转换为五线谱。在五线谱中，一字多音用圆滑线表示，而多音节词则是将单词按音节拆分开，写在每个音符底下，中间用连字符`-`连接

例如：
```py
import music21
import music21_svs_formats

music21_svs_formats.registAllFormats()

infile = "take me to your heart.ustx"
project = music21.converter.parseFile(infile, forceSource=True, hyphenLang="en_US")
project.show()
```

以前的行为：

<img width="1416" height="394" alt="image" src="https://github.com/user-attachments/assets/75a946b9-173a-403b-a5e4-45044285c184" />

现在的行为：

<img width="1407" height="382" alt="image" src="https://github.com/user-attachments/assets/6601796b-cd41-4cf1-9ca8-ee3634bbb396" />

[take me to your heart.zip](https://github.com/user-attachments/files/26899120/take.me.to.your.heart.zip)
