### PR TITLE
fix(ds): fix cumulative note position drift in parser

### DIFF
--- a/libresvip/plugins/ds/diffsinger_parser.py
+++ b/libresvip/plugins/ds/diffsinger_parser.py
@@ -47,7 +47,7 @@ class DiffSingerParser:
         all_notes = []
         for ds_item in ds_items:
             notes: list[Note] = []
-            cur_time = self.synchronizer.get_actual_ticks_from_secs(float(ds_item.offset))
+            cur_secs = float(ds_item.offset)
             prev_is_breath = False
             for lyric_index, slur_group in enumerate(
                 more_itertools.split_before(
@@ -61,8 +61,9 @@ class DiffSingerParser:
                     text = ds_item.text[lyric_index]
                     note_dur = ds_item.note_dur[note_index]
                     note = ds_item.note_seq[note_index]
-                    next_time = self.synchronizer.get_actual_ticks_from_secs_offset(
-                        int(cur_time), note_dur
+                    cur_time = self.synchronizer.get_actual_ticks_from_secs(cur_secs)
+                    next_time = self.synchronizer.get_actual_ticks_from_secs(
+                        cur_secs + note_dur
                     )
                     if text == "SP":
                         pass
@@ -90,7 +91,7 @@ class DiffSingerParser:
                                     lyric="-",
                                 )
                             )
-                    cur_time = next_time
+                    cur_secs += note_dur
             all_notes.extend(notes)
         return all_notes
 

--- a/libresvip/plugins/ds/diffsinger_parser.py
+++ b/libresvip/plugins/ds/diffsinger_parser.py
@@ -62,9 +62,7 @@ class DiffSingerParser:
                     note_dur = ds_item.note_dur[note_index]
                     note = ds_item.note_seq[note_index]
                     cur_time = self.synchronizer.get_actual_ticks_from_secs(cur_secs)
-                    next_time = self.synchronizer.get_actual_ticks_from_secs(
-                        cur_secs + note_dur
-                    )
+                    next_time = self.synchronizer.get_actual_ticks_from_secs(cur_secs + note_dur)
                     if text == "SP":
                         pass
                     elif text == "AP":


### PR DESCRIPTION
Replace tick-based accumulation with seconds-based accumulation in parse_notes().

The previous logic truncated cur_time to int on each iteration via get_actual_ticks_from_secs_offset(int(cur_time), note_dur), causing rounding errors to accumulate over many notes. This resulted in notes drifting further from their correct positions the later they appeared in the sequence.

Now each note's start/end tick is computed independently from the precise cumulative seconds value, eliminating the progressive offset.