### PR TITLE
Do not divide by zero parsing an AiSingers note without pitch points

### DIFF
--- a/libresvip/plugins/aisp/aisingers_parser.py
+++ b/libresvip/plugins/aisp/aisingers_parser.py
@@ -111,7 +111,7 @@ class AiSingersParser:
                 lyric=ais_note.lyric,
                 pronunciation=ais_note.pinyin,
             )
-            if self.options.import_pitch:
+            if self.options.import_pitch and ais_note.pit:
                 tick_step = note.length / len(ais_note.pit)
                 pitch_points.append(Point(x=note.start_pos + self.first_bar_length, y=-100))
                 for i in range(len(ais_note.pit)):

--- a/tests/test_aisp.py
+++ b/tests/test_aisp.py
@@ -1,0 +1,28 @@
+from libresvip.plugins.aisp.aisingers_parser import AiSingersParser
+from libresvip.plugins.aisp.model import AISNote
+from libresvip.plugins.aisp.options import InputOptions
+
+
+def test_parse_note_without_pitch_points() -> None:
+    # AISNote.pit defaults to an empty list, so a note without pitch data used
+    # to divide note.length by len(pit) == 0 and raise ZeroDivisionError.
+    parser = AiSingersParser(options=InputOptions(import_pitch=True))
+    parser.first_bar_length = 1920
+
+    note = AISNote(s=0, l=480, m=60, ly="a", py="a", pit=[])
+    notes, pitch_points = parser.parse_notes([note], 0)
+
+    assert len(notes) == 1
+    assert pitch_points == []
+
+
+def test_parse_note_with_pitch_points() -> None:
+    parser = AiSingersParser(options=InputOptions(import_pitch=True))
+    parser.first_bar_length = 1920
+
+    note = AISNote(s=0, l=480, m=60, ly="a", py="a", pit=[1.0, 2.0, 3.0])
+    notes, pitch_points = parser.parse_notes([note], 0)
+
+    assert len(notes) == 1
+    # start marker, one point per pitch value, and an end marker
+    assert len(pitch_points) == 5


### PR DESCRIPTION
Loading an AiSingers file whose note has no pitch points crashes with `ZeroDivisionError`. `AISNote.pit` defaults to an empty list, so a note without pitch data hits:

```python
# libresvip/plugins/aisp/aisingers_parser.py
tick_step = note.length / len(ais_note.pit)   # len(pit) == 0
```

`tick_step` is only used inside the `for i in range(len(ais_note.pit))` loop right below it, which does nothing when the list is empty, so I skip the whole pitch block when there are no points (this also covers `pit` being `None`, which the field validator allows). Added a test for the empty and populated cases.
