### PR TITLE
Default to 4/4 when a ufdata project has no time signatures

### DIFF
--- a/libresvip/plugins/ufdata/ufdata_parser.py
+++ b/libresvip/plugins/ufdata/ufdata_parser.py
@@ -64,7 +64,7 @@ class UFDataParser:
     def parse_time_signatures(
         time_signatures: list[UFTimeSignatures],
     ) -> list[TimeSignature]:
-        return [
+        time_signature_list = [
             TimeSignature(
                 bar_index=time_signature.measure_position,
                 numerator=time_signature.numerator,
@@ -72,6 +72,9 @@ class UFDataParser:
             )
             for time_signature in time_signatures
         ]
+        if not time_signature_list:
+            time_signature_list.append(TimeSignature(bar_index=0, numerator=4, denominator=4))
+        return time_signature_list
 
     def parse_tracks(self, tracks: list[UFTracks], tick_prefix: int) -> list[SingingTrack]:
         track_list = []

--- a/tests/test_ufdata.py
+++ b/tests/test_ufdata.py
@@ -1,0 +1,14 @@
+from libresvip.plugins.ufdata.model import UFData, UFProject
+from libresvip.plugins.ufdata.options import InputOptions
+from libresvip.plugins.ufdata.ufdata_parser import UFDataParser
+
+
+def test_parse_project_without_time_signatures() -> None:
+    # A ufdata project may carry no time signatures. parse_project used to read
+    # time_signatures[0] unconditionally and raise IndexError on such a file.
+    project = UFData(project=UFProject(measure_prefix=0, tracks=[], tempos=[], time_signatures=[]))
+    result = UFDataParser(InputOptions()).parse_project(project)
+
+    assert len(result.time_signature_list) == 1
+    default = result.time_signature_list[0]
+    assert (default.bar_index, default.numerator, default.denominator) == (0, 4, 4)


### PR DESCRIPTION
A UtaFormatix (ufdata) file that carries an empty `timeSignatures` array makes `parse_project` raise `IndexError` on `self.time_signatures[0]`. The mid importer already handles this by falling back to a 4/4 signature at bar 0, so I did the same thing in the ufdata parser. Added a small test covering the empty case.