### PR TITLE
preserve lyrics extensions and tied syllables in MusicXML

### DIFF
--- a/libresvip/middlewares/remove_lyric_symbols/__init__.py
+++ b/libresvip/middlewares/remove_lyric_symbols/__init__.py
@@ -1,0 +1,1 @@
+"""Middleware for removing numbers and punctuation from note lyrics."""

--- a/libresvip/middlewares/remove_lyric_symbols/options.py
+++ b/libresvip/middlewares/remove_lyric_symbols/options.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class ProcessOptions(BaseModel):
+    pass

--- a/libresvip/middlewares/remove_lyric_symbols/remove_lyric_symbols.py
+++ b/libresvip/middlewares/remove_lyric_symbols/remove_lyric_symbols.py
@@ -1,0 +1,37 @@
+import unicodedata
+from importlib.resources import files
+
+from libresvip.extension import base as plugin_base
+from libresvip.model.base import Project, SingingTrack
+
+from .options import ProcessOptions
+
+_STRUCTURAL_LYRICS = frozenset({"-", "+", "+~", "+*"})
+
+
+def remove_numbers_and_punctuation(lyric: str) -> str:
+    if lyric in _STRUCTURAL_LYRICS:
+        return lyric
+    return "".join(
+        char
+        for char in lyric
+        if (category := unicodedata.category(char)) != "Nd" and not category.startswith("P")
+    )
+
+
+class RemoveLyricSymbolsMiddleware(plugin_base.Middleware):
+    process_option_cls = ProcessOptions
+    info = plugin_base.MiddlewarePluginInfo.load_from_string(
+        (files(__package__) / "remove_lyric_symbols.yapsy-plugin").read_text(encoding="utf-8")
+    )
+    _alias_ = "remove_lyric_symbols"
+    _version_ = "1.0.0"
+
+    @classmethod
+    def process(cls, project: Project, options: plugin_base.OptionsDict) -> Project:
+        cls.process_option_cls.model_validate(options)
+        for track in project.track_list:
+            if isinstance(track, SingingTrack):
+                for note in track.note_list:
+                    note.lyric = remove_numbers_and_punctuation(note.lyric)
+        return project

--- a/libresvip/middlewares/remove_lyric_symbols/remove_lyric_symbols.yapsy-plugin
+++ b/libresvip/middlewares/remove_lyric_symbols/remove_lyric_symbols.yapsy-plugin
@@ -1,0 +1,7 @@
+[Core]
+name = Remove numbers and punctuation
+
+[Documentation]
+Author = SoulMelody
+Website = https://space.bilibili.com/175862486
+Description = Remove Unicode decimal digits and punctuation from note lyrics while preserving structural lyric markers.

--- a/libresvip/plugins/musicxml/musicxml_parser.py
+++ b/libresvip/plugins/musicxml/musicxml_parser.py
@@ -325,7 +325,8 @@ class MusicXMLParser:
         measure_nodes = part_node.measure
         tick_position = 0
         previous_tick_position = 0
-        incomplete_lyric_note: Note | None = None
+        incomplete_lyric_note_index: int | None = None
+        is_lyric_extension_active = False
         duration: int | None = None
         for measure_node in measure_nodes:
             for note_node in measure_node.content:
@@ -369,14 +370,24 @@ class MusicXMLParser:
                 key = note2midi(f"{step.value}{octave}") + alter
 
                 lyric_nodes = note_node.lyric
-                if any(
+                lyric_node = lyric_nodes[0] if lyric_nodes else None
+                has_lyric_text = lyric_node is not None and bool(lyric_node.text)
+                has_lyric_extension = lyric_node is not None and bool(lyric_node.extend)
+                if has_lyric_text:
+                    is_lyric_extension_active = has_lyric_extension
+                elif has_lyric_extension:
+                    is_lyric_extension_active = True
+
+                if not has_lyric_text and is_lyric_extension_active:
+                    lyric = "+~"
+                elif any(
                     slur.type_value in [StartStopContinue.CONTINUE, StartStopContinue.STOP]
                     for notation in note_node.notations
                     for slur in notation.slur
                 ):
                     lyric = "-"
-                elif len(lyric_nodes) and len(lyric_nodes[0].text):
-                    lyric = lyric_nodes[0].text[0].value
+                elif has_lyric_text:
+                    lyric = lyric_node.text[0].value
                 else:
                     lyric = DEFAULT_PHONEME
 
@@ -393,19 +404,19 @@ class MusicXMLParser:
                         start_pos=tick_position,
                         length=duration,
                     )
+                    note_index = len(notes)
+                    notes.append(note)
                     if len(lyric_nodes):
                         syllabic = self.syllabic_status(lyric_nodes[0])
                         if syllabic == Syllabic.BEGIN:
-                            incomplete_lyric_note = note
-                        elif syllabic == Syllabic.END and incomplete_lyric_note is not None:
-                            incomplete_lyric_note.lyric += lyric
-                            incomplete_lyric_note = None
+                            incomplete_lyric_note_index = note_index
+                        elif syllabic == Syllabic.END and incomplete_lyric_note_index is not None:
+                            notes[incomplete_lyric_note_index].lyric += lyric
+                            incomplete_lyric_note_index = None
                             note.lyric = "+"
-                        elif syllabic == Syllabic.MIDDLE and incomplete_lyric_note is not None:
-                            incomplete_lyric_note.lyric += lyric
+                        elif syllabic == Syllabic.MIDDLE and incomplete_lyric_note_index is not None:
+                            notes[incomplete_lyric_note_index].lyric += lyric
                             note.lyric = "+"
-                    notes.append(note)
-                    note_index = len(notes) - 1
                     fermata_shape = next(
                         (
                             (f.value.value if f.value else "")

--- a/libresvip/plugins/musicxml/musicxml_parser.py
+++ b/libresvip/plugins/musicxml/musicxml_parser.py
@@ -357,6 +357,7 @@ class MusicXMLParser:
 
                 rest_nodes = note_node.rest
                 if rest_nodes:
+                    is_lyric_extension_active = False
                     tick_position += duration
                     continue
 
@@ -372,11 +373,13 @@ class MusicXMLParser:
                 lyric_nodes = note_node.lyric
                 lyric_node = lyric_nodes[0] if lyric_nodes else None
                 has_lyric_text = lyric_node is not None and bool(lyric_node.text)
-                has_lyric_extension = lyric_node is not None and bool(lyric_node.extend)
-                if has_lyric_text:
-                    is_lyric_extension_active = has_lyric_extension
-                elif has_lyric_extension:
-                    is_lyric_extension_active = True
+                if lyric_node is not None and lyric_node.extend:
+                    for extend in lyric_node.extend:
+                        is_lyric_extension_active = (
+                            extend.type_value != StartStopContinue.STOP
+                        )
+                elif has_lyric_text:
+                    is_lyric_extension_active = False
 
                 if not has_lyric_text and is_lyric_extension_active:
                     lyric = "+~"

--- a/libresvip/plugins/musicxml/musicxml_parser.py
+++ b/libresvip/plugins/musicxml/musicxml_parser.py
@@ -375,9 +375,7 @@ class MusicXMLParser:
                 has_lyric_text = lyric_node is not None and bool(lyric_node.text)
                 if lyric_node is not None and lyric_node.extend:
                     for extend in lyric_node.extend:
-                        is_lyric_extension_active = (
-                            extend.type_value != StartStopContinue.STOP
-                        )
+                        is_lyric_extension_active = extend.type_value != StartStopContinue.STOP
                 elif has_lyric_text:
                     is_lyric_extension_active = False
 
@@ -417,7 +415,9 @@ class MusicXMLParser:
                             notes[incomplete_lyric_note_index].lyric += lyric
                             incomplete_lyric_note_index = None
                             note.lyric = "+"
-                        elif syllabic == Syllabic.MIDDLE and incomplete_lyric_note_index is not None:
+                        elif (
+                            syllabic == Syllabic.MIDDLE and incomplete_lyric_note_index is not None
+                        ):
                             notes[incomplete_lyric_note_index].lyric += lyric
                             note.lyric = "+"
                     fermata_shape = next(

--- a/tests/files/musicxml/v4/v4-lyrics-ties-extensions.musicxml
+++ b/tests/files/musicxml/v4/v4-lyrics-ties-extensions.musicxml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Voice</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>2</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>6</duration><type>half</type>
+        <lyric><syllabic>single</syllabic><text>Ooh</text><extend/></lyric>
+      </note>
+      <note>
+        <pitch><step>A</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>2</duration><tie type="start"/><type>quarter</type>
+      </note>
+    </measure>
+    <measure number="2">
+      <note>
+        <pitch><step>A</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>4</duration><tie type="stop"/><tie type="start"/><type>half</type>
+      </note>
+      <note>
+        <pitch><step>A</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>1</duration><tie type="stop"/><type>eighth</type>
+        <notations><slur type="stop" number="1"/></notations>
+      </note>
+      <note><rest/><duration>3</duration><type>quarter</type><dot/></note>
+    </measure>
+    <measure number="3">
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>3</duration><tie type="start"/><type>quarter</type><dot/>
+        <lyric><syllabic>begin</syllabic><text>a</text></lyric>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>2</duration><tie type="stop"/><type>quarter</type>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1</duration><type>eighth</type>
+        <lyric><syllabic>end</syllabic><text>gnus</text></lyric>
+      </note>
+      <note><rest/><duration>2</duration><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/tests/files/musicxml/v4/v4-lyrics-ties-extensions.musicxml
+++ b/tests/files/musicxml/v4/v4-lyrics-ties-extensions.musicxml
@@ -12,7 +12,7 @@
       </attributes>
       <note>
         <pitch><step>A</step><octave>4</octave></pitch>
-        <duration>6</duration><type>half</type>
+        <duration>6</duration><type>half</type><dot/>
         <lyric><syllabic>single</syllabic><text>Ooh</text><extend/></lyric>
       </note>
       <note>

--- a/tests/files/musicxml/v4/v4-lyrics-ties-extensions.musicxml
+++ b/tests/files/musicxml/v4/v4-lyrics-ties-extensions.musicxml
@@ -35,6 +35,10 @@
     <measure number="3">
       <note>
         <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>1</duration><type>eighth</type>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
         <duration>3</duration><tie type="start"/><type>quarter</type><dot/>
         <lyric><syllabic>begin</syllabic><text>a</text></lyric>
       </note>
@@ -47,7 +51,23 @@
         <duration>1</duration><type>eighth</type>
         <lyric><syllabic>end</syllabic><text>gnus</text></lyric>
       </note>
-      <note><rest/><duration>2</duration><type>quarter</type></note>
+      <note><rest/><duration>1</duration><type>eighth</type></note>
+    </measure>
+    <measure number="4">
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>2</duration><type>quarter</type>
+        <lyric><syllabic>single</syllabic><text>ah</text><extend/></lyric>
+      </note>
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>2</duration><type>quarter</type>
+        <lyric><extend type="stop"/></lyric>
+      </note>
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>4</duration><type>half</type>
+      </note>
     </measure>
   </part>
 </score-partwise>

--- a/tests/test_musicxml.py
+++ b/tests/test_musicxml.py
@@ -382,7 +382,17 @@ def test_musicxml_lyrics_ties_and_extensions_export_to_ustx(tmp_path: pathlib.Pa
     project = MusicXMLConverter.load(mxl_path, {})
     track = project.track_list[0]
     assert isinstance(track, SingingTrack)
-    expected_lyrics = ["Ooh", "+~", "+~", "agnus", "+"]
+    expected_lyrics = [
+        "Ooh",
+        "+~",
+        "+~",
+        DEFAULT_PHONEME,
+        "agnus",
+        "+",
+        "ah",
+        DEFAULT_PHONEME,
+        DEFAULT_PHONEME,
+    ]
     assert [note.lyric for note in track.note_list] == expected_lyrics
 
     ustx_project = UstxGenerator(UstxOutputOptions()).generate_project(project)

--- a/tests/test_musicxml.py
+++ b/tests/test_musicxml.py
@@ -9,6 +9,8 @@ from libresvip.core.constants import DEFAULT_PHONEME
 from libresvip.extension.manager import get_svs_plugin_by_suffix, plugin_manager
 from libresvip.model.base import SingingTrack
 from libresvip.plugins.musicxml.dynamics import DYNAMIC_TO_VELOCITY
+from libresvip.plugins.ustx.options import OutputOptions as UstxOutputOptions
+from libresvip.plugins.ustx.ustx_generator import UstxGenerator
 from libresvip.utils.binary.midi import cc11_to_db_change
 
 musicxml_test_base_path = pathlib.Path(__file__).parent / "files" / "musicxml"
@@ -357,6 +359,34 @@ def test_mxl_extension_compressed(tmp_path: pathlib.Path) -> None:
     project = MusicXMLConverter.load(mxl_path, {})
     assert len(project.song_tempo_list) >= 2
     assert project.song_tempo_list[1].position == 1920 + 960
+
+
+def test_musicxml_lyrics_ties_and_extensions_export_to_ustx(tmp_path: pathlib.Path) -> None:
+    source = (musicxml_v4_path / "v4-lyrics-ties-extensions.musicxml").read_bytes()
+    mxl_path = tmp_path / "lyrics.mxl"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "META-INF/container.xml",
+            (
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                "<container>"
+                '<rootfiles><rootfile full-path="score.musicxml" '
+                'media-type="application/vnd.recordare.musicxml+xml"/></rootfiles>'
+                "</container>"
+            ),
+        )
+        zf.writestr("score.musicxml", source)
+    mxl_path.write_bytes(buf.getvalue())
+
+    project = MusicXMLConverter.load(mxl_path, {})
+    track = project.track_list[0]
+    assert isinstance(track, SingingTrack)
+    expected_lyrics = ["Ooh", "+~", "+~", "agnus", "+"]
+    assert [note.lyric for note in track.note_list] == expected_lyrics
+
+    ustx_project = UstxGenerator(UstxOutputOptions()).generate_project(project)
+    assert [note.lyric for note in ustx_project.voice_parts[0].notes] == expected_lyrics
 
 
 def test_xml_content_sniff_rejects_foreign_xml(tmp_path: pathlib.Path) -> None:

--- a/tests/test_remove_lyric_symbols.py
+++ b/tests/test_remove_lyric_symbols.py
@@ -1,0 +1,39 @@
+from libresvip.middlewares.remove_lyric_symbols.remove_lyric_symbols import (
+    RemoveLyricSymbolsMiddleware,
+    remove_numbers_and_punctuation,
+)
+from libresvip.model.base import InstrumentalTrack, Note, Project, SingingTrack
+
+
+def test_remove_numbers_and_punctuation_handles_unicode_characters() -> None:
+    assert remove_numbers_and_punctuation("Verse 1\u0662\uff13,\uff0c!。") == "Verse "
+
+
+def test_remove_numbers_and_punctuation_removes_hyphens_and_dashes() -> None:
+    assert remove_numbers_and_punctuation("co-operate\u2014now") == "cooperatenow"
+
+
+def test_remove_numbers_and_punctuation_preserves_structural_lyrics() -> None:
+    for lyric in ("-", "+", "+~", "+*"):
+        assert remove_numbers_and_punctuation(lyric) == lyric
+
+
+def test_middleware_updates_singing_lyrics_without_removing_notes() -> None:
+    cleaned_note = Note(start_pos=120, length=480, lyric="123!?", pronunciation="s a")
+    structural_note = Note(start_pos=600, length=480, lyric="+~")
+    project = Project(
+        track_list=[
+            SingingTrack(note_list=[cleaned_note, structural_note]),
+            InstrumentalTrack(audio_file_path="backing.wav"),
+        ]
+    )
+
+    result = RemoveLyricSymbolsMiddleware.process(project, {})
+
+    assert result is project
+    assert cleaned_note.lyric == ""
+    assert cleaned_note.start_pos == 120
+    assert cleaned_note.length == 480
+    assert cleaned_note.pronunciation == "s a"
+    assert structural_note.lyric == "+~"
+    assert len(result.track_list) == 2


### PR DESCRIPTION
This fixes tied syllables, and adds regression tests in MusicXML. Manually verified using MXL -> USTX conversion, the extend MusicXML tag is now supported, and extended notes are carried over in USTX as +~.